### PR TITLE
feature: add front end parser

### DIFF
--- a/app/schema/table.ts
+++ b/app/schema/table.ts
@@ -9,9 +9,22 @@ export interface TableConfig {
   maxColumn: string;
   validation?: (row: any[]) => boolean;
   getFilePath: (sheet: string) => string;
+  feParser?: (data: any[], sheet: string) => any;
 }
 
 export const defaultColumnType = 'string';
 export const defaultValidation = (row: any[]): boolean => {
   return row.some(item => item.key === '审核状态' && item.value !== null);
 };
+
+export function getCellByType(row: any[], type: string): any {
+  return row.find(cell => cell.type === type);
+}
+
+export function getCellByName(row: any[], key: string): any {
+  return row.find(cell => cell.key === key);
+}
+
+export function getAllCellsByType(row: any[], type: string): any {
+  return row.filter(cell => cell.type === type);
+}

--- a/app/schema/table_clinic.ts
+++ b/app/schema/table_clinic.ts
@@ -1,4 +1,4 @@
-import { TableConfig } from './table';
+import { TableConfig, getCellByName, getCellByType } from './table';
 
 const clinicTable: TableConfig = {
   guid: 'JgXjYCJJTRQxJ3GP',
@@ -9,7 +9,18 @@ const clinicTable: TableConfig = {
   typeRow: 3,
   defaultValueRow: 4,
   maxColumn: 'G',
-  getFilePath: () => '义诊/data.json',
+  getFilePath: () => 'clinic/data.json',
+  feParser: (data: any[]) => {
+    return data.map(row => {
+      return {
+        name: getCellByName(row, '义诊单位或个人').value,
+        contacts: getCellByType(row, 'contact').value,
+        date: getCellByType(row, 'date').value,
+        url: getCellByType(row, 'url').value,
+        remark: getCellByName(row, '备注').value,
+      };
+    });
+  },
 };
 
 export default clinicTable;

--- a/app/schema/table_donation.ts
+++ b/app/schema/table_donation.ts
@@ -1,4 +1,4 @@
-import { TableConfig } from './table';
+import { TableConfig, getCellByName, getCellByType } from './table';
 
 const donationTable: TableConfig = {
   guid: 'W3gxW6cwkYTDY6DD',
@@ -9,7 +9,19 @@ const donationTable: TableConfig = {
   typeRow: 3,
   defaultValueRow: 4,
   maxColumn: 'H',
-  getFilePath: () => '捐赠/data.json',
+  getFilePath: () => 'donation/data.json',
+  feParser: (data: any[]) => {
+    return data.map(row => {
+      return {
+        name: getCellByName(row, '受赠方').value,
+        method: getCellByName(row, '收款方式').value,
+        info: getCellByName(row, '收款账户').value,
+        date: getCellByType(row, 'date').value,
+        url: getCellByType(row, 'url').value,
+        status: getCellByName(row, '当前状态').value,
+      };
+    });
+  },
 };
 
 export default donationTable;

--- a/app/schema/table_hospital.ts
+++ b/app/schema/table_hospital.ts
@@ -1,15 +1,35 @@
-import { TableConfig } from './table';
+import { TableConfig, getCellByName, getAllCellsByType, getCellByType } from './table';
+import pinyin = require('pinyin');
 
 const hospitalTable: TableConfig = {
-  guid: 'q6WP3DpKKgVW63Pr',
+  guid: 'k399pHyt6HKvW6xR',
   sheets: [ '武汉市', '黄石市', '十堰市', '宜昌市', '襄阳市', '鄂州市', '荆门市', '孝感市', '荆州市', '黄冈市', '咸宁市', '随州市', '施恩土家族苗族自治州', '仙桃市', '潜江市', '天门市' ],
   skipRows: 6,
   skipColumns: 1,
-  nameRow: 4,
-  typeRow: 5,
-  defaultValueRow: 6,
-  maxColumn: 'BR',
-  getFilePath: (sheet: string) => `医院/湖北/${sheet}.json`,
+  nameRow: 3,
+  typeRow: 4,
+  defaultValueRow: 5,
+  maxColumn: 'AE',
+  getFilePath: (sheet: string) => `hospital/hubei/${pinyin(sheet, { style: pinyin.STYLE_NORMAL }).join('')}.json`,
+  feParser: (data: any[], sheet: string) => {
+    return data.map(row => {
+      return {
+        province: '湖北',
+        city: sheet,
+        district: getCellByName(row, '区县').value,
+        name: getCellByName(row, '医院名称').value,
+        supplies: getAllCellsByType(row, 'supply').filter((cell: any) => cell.value !== 0).map((cell: any) => {
+          return {
+            key: cell.key,
+            value: cell.value,
+            specification: cell.specification,
+          };
+        }),
+        url: getCellByType(row, 'url').value,
+        remark: getCellByName(row, '备注').value,
+      };
+    });
+  },
 };
 
 export default hospitalTable;

--- a/app/schema/table_logistical.ts
+++ b/app/schema/table_logistical.ts
@@ -1,4 +1,4 @@
-import { TableConfig } from './table';
+import { TableConfig, getCellByName, getCellByType } from './table';
 
 const logisticalTable: TableConfig = {
   guid: 'RTHXp3ghtKXY3GcC',
@@ -9,7 +9,19 @@ const logisticalTable: TableConfig = {
   typeRow: 3,
   defaultValueRow: 4,
   maxColumn: 'H',
-  getFilePath: () => '物流/data.json',
+  getFilePath: () => 'logistical/data.json',
+  feParser: (data: any[]) => {
+    return data.map(row => {
+      return {
+        name: getCellByName(row, '物流名称').value,
+        area: getCellByName(row, '物流区域').value,
+        contacts: getCellByType(row, 'contact').value,
+        date: getCellByType(row, 'date').value,
+        url: getCellByType(row, 'url').value,
+        remark: getCellByName(row, '备注').value,
+      };
+    });
+  },
 };
 
 export default logisticalTable;

--- a/app/schema/table_travel_hotel.ts
+++ b/app/schema/table_travel_hotel.ts
@@ -1,4 +1,4 @@
-import { TableConfig } from './table';
+import { TableConfig, getCellByName, getCellByType } from './table';
 
 const tavelHotelTable: TableConfig = {
   guid: 'pdHRcXyKqJdqPyGJ',
@@ -9,7 +9,21 @@ const tavelHotelTable: TableConfig = {
   typeRow: 4,
   defaultValueRow: 5,
   maxColumn: 'J',
-  getFilePath: () => '武汉在外游客旅游/data.json',
+  getFilePath: () => 'travel_hotel/data.json',
+  feParser: (data: any[]) => {
+    return data.map(row => {
+      return {
+        province: getCellByName(row, '省份').value,
+        city: getCellByName(row, '市-区').value,
+        contacts: getCellByType(row, 'contact').value,
+        address: getCellByType(row, 'address').value,
+        name: getCellByName(row, '联系人(酒店名称或者政府部门）').value,
+        date: getCellByType(row, 'date').value,
+        url: getCellByType(row, 'url').value,
+        remark: getCellByName(row, '备注').value,
+      };
+    });
+  },
 };
 
 export default tavelHotelTable;

--- a/app/service/data_format.ts
+++ b/app/service/data_format.ts
@@ -55,7 +55,12 @@ export default class DataFormatService extends Service {
   }
 
   public static contactFormatter: FormatFunc = item => {
-    const v: string = item.value.toString();
+    let v: any = item.value;
+    if (v === null) {
+      item.value = [];
+      return item;
+    }
+    v = v.toString();
     const contacts: {name: string; tel: string}[] = [];
     v.replace('：', ':').split('|').forEach(contact => {
       const s = contact.trim().split(':');
@@ -142,7 +147,7 @@ export default class DataFormatService extends Service {
     if (item.value === null) {
       return item;
     }
-    const vs = item.value.split('|');
+    const vs = item.value.toString().split('|');
     try {
       item.value = parseInt(vs[0].trim());
     } catch {

--- a/app/service/shimo.ts
+++ b/app/service/shimo.ts
@@ -33,6 +33,9 @@ export default class ShimoService extends Service {
           if (data.length > 0) {
             // only update if have data
             await this.ctx.service.github.updateRepo(`data/json/${filePath}`, JSON.stringify(data));
+            if (table.feParser) {
+              await this.ctx.service.github.updateRepo(`data/fe/${filePath}`, JSON.stringify(table.feParser(data, sheet)));
+            }
           }
         } catch (e) {
           logger.error(e);
@@ -131,7 +134,7 @@ export default class ShimoService extends Service {
     const res: any[] = [];
     while (!done) {
       range = `${sheetName}!${minCol}${row}:${maxCol}${row + this.rowBatch}`;
-      row += this.rowBatch;
+      row += this.rowBatch + 1;
       const values = await this.getFileContentRange(accessToken, tableConfig.guid, range);
       for (const row of values) {
         if (!row.some(v => v !== null)) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "egg-scripts": "^2.6.0",
     "http2": "^3.3.7",
     "moment": "^2.24.0",
+    "pinyin": "^2.9.0",
     "querystring": "^0.2.0",
     "request": "^2.88.0"
   },


### PR DESCRIPTION
每个表添加一个 feParser，可以将当前二维表数据解析为前端可以直接使用的数据结构，并提交到 fe 目录中，并使用 pinyin 库将所有中文改为英文路径

Signed-off-by: Frankzhaopku <syzhao1988@126.com>