### PR TITLE
Patch 1 Readme翻译已修正

### DIFF
--- a/READMEMandarin.md
+++ b/READMEMandarin.md
@@ -37,4 +37,4 @@ $ npm start
 
 ## 功能架构图
 
-![arch](https://github.com/FinnJC/data-sync/blob/patch-1/static/architectureMandarin.puml)
+![arch](http://api.hypertrons.io/umlrenderer/github/wuhan2020/data-sync?path=static/architecture.puml)

--- a/READMEMandarin.md
+++ b/READMEMandarin.md
@@ -37,4 +37,4 @@ $ npm start
 
 ## 功能架构图
 
-![arch](http://api.hypertrons.io/umlrenderer/github/wuhan2020/data-sync?path=static/architecture.puml)
+![arch](https://github.com/FinnJC/data-sync/blob/patch-2/static/architectureMandarin.puml)

--- a/READMEMandarin.md
+++ b/READMEMandarin.md
@@ -37,4 +37,4 @@ $ npm start
 
 ## 功能架构图
 
-![arch](https://github.com/FinnJC/data-sync/blob/patch-2/static/architectureMandarin.puml)
+![arch](https://github.com/FinnJC/data-sync/blob/patch-1/static/architectureMandarin.puml)

--- a/READMEMandarin.md
+++ b/READMEMandarin.md
@@ -1,0 +1,40 @@
+# data-sync
+
+![travis](https://travis-ci.com/wuhan2020/data-sync.svg?branch=master)
+
+武汉新型冠状病毒防疫信息收集平台-数据同步服务
+using typescript && egg
+
+## 快速上手指南
+
+### 开发
+
+```bash
+$ npm i
+$ npm run dev
+$ open http://localhost:7001/
+```
+
+不要再开发者模式下进行 tsc编译, 如果你需要运行 `tsc` ，则你必须在`npm run dev`之前先运行 `npm run clean` 。
+
+### 部署
+
+```bash
+$ npm run tsc
+$ npm start
+```
+
+### Npm 代码
+
+- 使用 `npm run lint` 来检查代码的样式
+- 使用 `npm test` 来执行单位测试
+- se `npm run clean` 在开发者模式下一次性清理编译完的js
+
+### 需求
+
+- Node.js 8.x
+- Typescript 2.8+
+
+## 功能架构图
+
+![arch](http://api.hypertrons.io/umlrenderer/github/wuhan2020/data-sync?path=static/architecture.puml)

--- a/static/architectureMandarin.puml
+++ b/static/architectureMandarin.puml
@@ -1,0 +1,78 @@
+Skip to content
+Pull requests
+Issues
+Marketplace
+Explore
+@FinnJC
+Learn Git and GitHub without any code!
+
+Using the Hello World guide, you’ll start a branch, write comments, and open a pull request.
+Code Issues 6 Pull requests 1 Projects 0 Actions Wiki Security Pulse Community
+data-sync/static/architecture.puml
+@bkbabydp bkbabydp update arch diagram ca45bdf 3 days ago
+51 lines (38 sloc) 1.33 KB
+@startuml Architecture diagram for wuhan2020 project
+!include https://raw.githubusercontent.com/RicardoNiepel/C4-PlantUML/master/C4_Container.puml
+
+'LAYOUT_WITH_LEGEND()
+'LAYOUT_AS_SKETCH()
+
+title
+
+    <u> wuhan2020计划组织架构图 </u>
+
+end title
+
+Person(volunteer, "志愿者")
+
+
+    System(shimo, "石墨", "表格收集")
+    System(github, "wuhan2020/wuhan2020", "Yaml")
+
+
+System_Boundary(data, "wuhan2020/数据汇总"){
+    System(dataFetcher, "收据收集", "")
+    System_Boundary(dataParser, "数据解析"){
+        System_Ext(pluginYML, "YAML 插件")
+        System_Ext(pluginXML, "XML 插件")
+        System_Ext(pluginCVS, "CVS 插件")
+        System_Ext(pluginJSON, "JSON 插件")
+        System_Ext(pluginOther, "其他")
+    }
+    System(dataExport, "数据发布", "")
+}
+
+System_Boundary(web, "wuhan2020/网站服务器"){
+    System_Boundary(api, "Rest-API 服务器"){
+        System(apiMap, "地图 API", "")
+        System(apiWeb, "网站 API", "")
+    }
+    System(front, "网站前端", "")
+}
+
+Rel(volunteer, shimo, "填写")
+Rel(shimo, dataFetcher, "收集")
+Rel(dataFetcher, dataParser, "解析")
+Rel(dataParser, dataExport, "发布")
+Rel(dataExport, github, "YAML 更新")
+Rel(apiWeb, github, "获取 YAML")
+Rel(front, api, "提交")
+Rel(apiMap, dataExport, "获取 JSON")
+
+center footer Architecture diagram for wuhan2020 project
+
+@enduml
+
+    © 2020 GitHub, Inc.
+    Terms
+    Privacy
+    Security
+    Status
+    Help
+
+    Contact GitHub
+    Pricing
+    API
+    Training
+    Blog
+    About


### PR DESCRIPTION
插入不了翻译后的流程图的原因是：目标路径找不到图片资源；

解决办法：需要将翻译后的流程图architectureManderin.puml文件提交到原项目wuhan2020/data-sync/static下。